### PR TITLE
Fix/rls policies and auth setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 next-env.d.ts
 
 .trash
+PRPs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,10 @@ SUPABASE_SERVICE_ROLE=<from-supabase-project-settings>
    - Shared code in `supabase/functions/_shared/`
    - Deploy with `supabase functions deploy <function-name>`
    - Add secrets via Supabase dashboard (Project Settings > Edge Functions)
+   - Required Edge Function secrets for broadcast features:
+     - `WHATSAPP_ACCESS_TOKEN` - WhatsApp Cloud API permanent token
+     - `WHATSAPP_BUSINESS_ACCOUNT_ID` - WhatsApp Business Account ID
+     - `WHATSAPP_API_PHONE_NUMBER_ID` - Phone Number ID from WhatsApp API Setup
 
 4. **Component development**:
    - UI components in `components/ui/` (shadcn/ui based)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,254 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Receevi is an open-source WhatsApp Business solution built with Next.js 14, Supabase, and the WhatsApp Cloud API. It acts as a webhook receiver for WhatsApp Cloud API, enabling businesses to manage messages, contacts, and broadcast campaigns through a web interface similar to WhatsApp Web.
+
+## Common Commands
+
+### Development
+```bash
+npm run dev              # Start development server on localhost:3000
+npm run build           # Build for production
+npm start               # Start production server
+npm run lint            # Run ESLint
+```
+
+### Supabase CLI
+```bash
+supabase login                            # Login to Supabase CLI
+supabase link --project-ref <ref-id>      # Link to Supabase project
+supabase db push                          # Push database migrations
+supabase functions deploy                 # Deploy all edge functions
+supabase functions deploy <function-name> # Deploy specific edge function
+```
+
+## Architecture
+
+### Next.js App Router Structure
+
+The project uses Next.js 14 with App Router:
+
+- **`app/(authorized)/`** - Protected routes requiring authentication
+  - **`(panel)/`** - Main application panel with sidebar layout
+    - `chats/` - WhatsApp chat interface with message sending/receiving
+    - `contacts/` - Contact management and bulk import
+    - `bulk-send/` - Broadcast message campaigns
+    - `users/` - User management (admin only)
+  - `setup/` - Initial setup wizard
+  - `post-login/` - Post-authentication redirect handler
+  - `update-password/` - Password change page
+
+- **`app/webhook/`** - WhatsApp Cloud API webhook endpoint (receives all WhatsApp events)
+- **`app/api/sendMessage/`** - API route for sending WhatsApp messages
+
+### Authentication & Authorization
+
+- Uses Supabase Auth with cookie-based sessions
+- Middleware (`middleware.ts`) protects routes using `@/utils/supabase/middleware`
+- Two user roles:
+  - **Admin**: Full access to all features including user management
+  - **Agent**: Limited access (can view/send messages but cannot manage users)
+- Role-based access enforced via:
+  - Supabase RLS policies (database level)
+  - JWT claims in user metadata
+  - Custom `authorize()` function checks role permissions
+
+### Database Layer - Repository Pattern
+
+The codebase uses a **repository pattern** with factory methods for dependency injection:
+
+```
+lib/repositories/
+  ├── contacts/
+  │   ├── ContactRepository.ts (interface)
+  │   ├── ContactRepositorySupabaseImpl.ts (implementation)
+  │   ├── ContactBrowserFactory.ts (client-side factory)
+  │   └── ContactServerFactory.ts (server-side factory)
+  ├── broadcast/
+  ├── contact-tag/
+  ├── message-template/
+  └── setup/
+```
+
+**Key points:**
+- Use factories to instantiate repositories (they handle Supabase client creation)
+- Browser factories for client components
+- Server factories for server components and API routes
+- All repositories use TypeScript interfaces for type safety
+
+### Supabase Integration
+
+Three types of Supabase clients are used throughout the app:
+
+1. **Service Client** (`lib/supabase/service-client.ts`)
+   - Uses `SUPABASE_SERVICE_ROLE` key (bypasses RLS)
+   - Used in webhook endpoint and system operations
+   - Has full database access
+
+2. **Server Client** (`utils/supabase-server.ts`)
+   - Uses `SUPABASE_ANON_KEY` with cookie-based auth
+   - Used in Server Components and Server Actions
+   - Respects RLS policies based on authenticated user
+
+3. **Browser Client** (`utils/supabase-browser.ts`)
+   - Used in Client Components
+   - Cookie-based session management
+   - Real-time subscriptions for live updates
+
+### Webhook Flow
+
+1. WhatsApp Cloud API sends events to `/webhook` endpoint
+2. Signature verification using `FACEBOOK_APP_SECRET`
+3. Webhook payload stored in `webhook` table for audit
+4. Events processed:
+   - **Messages**: Stored in `messages` table, contacts upserted
+   - **Statuses**: Updates message delivery/read status
+   - **Media**: Downloaded and stored in Supabase Storage
+5. Triggers Supabase Edge Functions:
+   - `update-unread-count` - Updates unread message counters
+   - Broadcast tracking functions
+
+### Message Sending
+
+Messages are sent via:
+1. Client calls `/api/sendMessage` API route
+2. API route calls WhatsApp Cloud API with `WHATSAPP_ACCESS_TOKEN`
+3. Message stored in database with `is_received: false`
+4. Status updates received via webhook (sent/delivered/read/failed)
+
+### Key Database Tables
+
+- **contacts** - WhatsApp contacts with profile info, last message timestamp, unread count, and tags
+- **messages** - All messages (sent/received) with WhatsApp message ID (`wam_id`), JSON payload, and status timestamps
+- **webhook** - Raw webhook payloads for debugging
+- **message_template** - WhatsApp approved message templates synced from API
+- **contact_tag** - Tags for organizing contacts
+- **broadcast** - Broadcast campaigns
+- **broadcast_contact** - Many-to-many relationship between broadcasts and contacts
+- **setup** - System configuration and setup status
+- **profiles** - User profile information
+- **user_roles** - User role assignments (admin/agent)
+
+### Supabase Edge Functions
+
+Located in `supabase/functions/`:
+- **bulk-send** - Process bulk message campaigns
+- **send-message-batch** - Send messages in batches
+- **sync-message-templates** - Sync templates from WhatsApp API
+- **update-unread-count** - Update unread message counters
+- **setup** - Initial setup wizard backend
+- **insert-bulk-contacts** - Bulk contact import
+
+### Real-time Features
+
+The app uses Supabase Realtime for live updates:
+- Message list updates when new messages arrive
+- Contact list updates when new messages received
+- Broadcast status updates during campaign execution
+- Unread count updates
+
+Enable realtime on tables via migrations (see `20230411173729_enable_realtime.sql`).
+
+### Path Aliases
+
+Configured in `tsconfig.json`:
+- `@/components/*` → `./components/*`
+- `@/lib/*` → `./lib/*`
+- `@/utils/*` → `./utils/*`
+- `@/types/*` → `./types/*`
+
+## Environment Variables
+
+Required environment variables (see `.env.example`):
+
+```bash
+# JWT secret for custom token signing
+JWT_SECRET_KEY=<random-hex-32>
+
+# WhatsApp webhook verification
+WEBHOOK_VERIFY_TOKEN=<random-hex-32>
+
+# Facebook/WhatsApp API credentials
+FACEBOOK_APP_SECRET=<from-facebook-app-settings>
+WHATSAPP_ACCESS_TOKEN=<permanent-token>
+WHATSAPP_API_PHONE_NUMBER_ID=<from-whatsapp-api-setup>
+WHATSAPP_BUSINESS_ACCOUNT_ID=<from-whatsapp-api-setup>
+
+# Supabase credentials
+SUPABASE_URL=<from-supabase-project-settings>
+SUPABASE_ANON_KEY=<from-supabase-project-settings>
+SUPABASE_SERVICE_ROLE=<from-supabase-project-settings>
+```
+
+**Important**: Never commit actual secrets. The `.env.example` should contain only placeholder values.
+
+## Development Workflow
+
+1. **Local development**:
+   - Copy `.env.example` to `.env.local` and fill in values
+   - Run `npm run dev`
+   - Supabase can be local (with `supabase start`) or remote
+
+2. **Database changes**:
+   - Create migration files in `supabase/migrations/`
+   - Use timestamp prefix: `YYYYMMDDHHMMSS_description.sql`
+   - Push with `supabase db push`
+
+3. **Edge function changes**:
+   - Edit in `supabase/functions/<function-name>/`
+   - Shared code in `supabase/functions/_shared/`
+   - Deploy with `supabase functions deploy <function-name>`
+   - Add secrets via Supabase dashboard (Project Settings > Edge Functions)
+
+4. **Component development**:
+   - UI components in `components/ui/` (shadcn/ui based)
+   - Feature components co-located with pages in `app/` directory
+   - Use Server Components by default, add `"use client"` only when needed
+   - Client components needed for: React hooks, event handlers, browser APIs, Supabase realtime
+
+## Key Technologies
+
+- **Next.js 14**: App Router, Server Components, Server Actions
+- **Supabase**: Database (PostgreSQL), Auth, Storage, Realtime, Edge Functions
+- **TypeScript**: Strict mode enabled
+- **Tailwind CSS**: Utility-first styling
+- **shadcn/ui**: UI component library (Radix UI + Tailwind)
+- **React Hook Form + Zod**: Form validation
+- **TanStack Query**: Data fetching and caching (used in some components)
+- **dayjs**: Date/time manipulation
+
+## Testing the Integration
+
+1. Send test message to WhatsApp number
+2. Check webhook logs: `app/webhook/route.ts` console output
+3. Verify message appears in Supabase `messages` table
+4. Check contact appears in UI at `/chats`
+5. Reply from UI and verify delivery via WhatsApp status updates
+
+## Important Notes
+
+- The webhook endpoint (`/webhook`) must be publicly accessible for WhatsApp to send events
+- WhatsApp requires HTTPS for webhooks (use Vercel deployment or ngrok for local testing)
+- Message templates must be pre-approved by Facebook before they can be used in broadcasts
+- Rate limits apply to WhatsApp Cloud API (check Facebook documentation)
+- Supabase RLS policies enforce security at database level - always test with appropriate user roles
+- Media files are stored in Supabase Storage buckets (`avatars` and `media`)
+
+### RLS Policy Pattern (CRITICAL)
+
+**Important**: Due to Supabase SSR limitations, custom JWT claims from auth hooks aren't always accessible in RLS policy context. All RLS policies use a **fallback pattern**:
+
+```sql
+-- Always use this pattern for role-based RLS policies:
+USING (
+    -- Try JWT claim first
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    -- Fallback to user_roles table lookup
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+)
+```
+
+This ensures policies work reliably even when `auth.jwt() ->> 'user_role'` returns NULL. See migration `20251111230921_fix-rls-policies-with-fallback.sql` for complete implementation.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,13 @@ This project is meant to be used as whatsapp cloud api webhook receiver. This pr
     ON CONFLICT (user_id, role) DO NOTHING;
     ```
 - Go to Supabase > Project Settings > Edge Functions
-- Add 2 new secrets
+- Add 3 new secrets (required for broadcast/bulk send features)
     - Secret name: `WHATSAPP_ACCESS_TOKEN`
-    - Value: Whatsapp webhook verify token you generated in prerequisites
+    - Value: Whatsapp cloud API permanent token
     - Secret name: `WHATSAPP_BUSINESS_ACCOUNT_ID`
     - Value: WhatsApp Business Account ID taken from developer console
+    - Secret name: `WHATSAPP_API_PHONE_NUMBER_ID`
+    - Value: Phone number ID (from WhatsApp > API Setup in Facebook Developer Console)
 
 ### Whatsapp setup
 - Go to https://developers.facebook.com/apps/

--- a/README.md
+++ b/README.md
@@ -90,8 +90,25 @@ This project is meant to be used as whatsapp cloud api webhook receiver. This pr
     ```bash
     supabase functions deploy
     ```
+- **Enable Auth Hook** (REQUIRED for authentication to work)
+    - Go to Supabase > Authentication > Hooks
+    - Find "Custom Access Token" hook
+    - Click "Enable Hook"
+    - Set Method: `Postgres Function`
+    - Set Schema: `public`
+    - Set Function: `custom_access_token_hook`
+    - Click "Save"
 - Go to Supabase > Authentication > Add user > Create New User
 - Enter email address and new password to create a user
+- **Add Admin Role to User** (REQUIRED - run this in SQL Editor)
+    ```sql
+    -- Replace with your user's email
+    INSERT INTO public.user_roles (user_id, role)
+    SELECT id, 'admin'::public.app_role
+    FROM auth.users
+    WHERE email = 'your-email@example.com'
+    ON CONFLICT (user_id, role) DO NOTHING;
+    ```
 - Go to Supabase > Project Settings > Edge Functions
 - Add 2 new secrets
     - Secret name: `WHATSAPP_ACCESS_TOKEN`

--- a/app/(authorized)/(panel)/chats/[wa_id]/MessageListClient.tsx
+++ b/app/(authorized)/(panel)/chats/[wa_id]/MessageListClient.tsx
@@ -10,6 +10,7 @@ import ReceivedTemplateMessageUI from "./ReceivedTemplateMessageUI"
 import { markAsRead } from "./markAsRead"
 import ReceivedVideoMessageUI from "./ReceivedVideoMessageUI"
 import ReceivedDocumentMessageUI from "./ReceivedDocumentMessageUI"
+import ReceivedAudioMessageUI from "./ReceivedAudioMessageUI"
 import ReceivedButtonMessageUI from "./ReceivedButtonMessageUI"
 import { useSupabase } from "@/components/supabase-provider"
 
@@ -207,6 +208,8 @@ export default function MessageListClient({ from }: { from: string }) {
                                                         return <ReceivedTemplateMessageUI message={messageBody as TemplateMessage} />
                                                     case "document":
                                                         return <ReceivedDocumentMessageUI message={message} />
+                                                    case "audio":
+                                                        return <ReceivedAudioMessageUI message={message} />
                                                     case "button":
                                                         return <ReceivedButtonMessageUI buttonMessage={messageBody as ButtonMessage} />
                                                     default:

--- a/app/(authorized)/(panel)/chats/[wa_id]/MessageListClient.tsx
+++ b/app/(authorized)/(panel)/chats/[wa_id]/MessageListClient.tsx
@@ -2,7 +2,7 @@
 
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react"
 import { DBTables } from "@/lib/enums/Tables"
-import { MessageJson, TemplateMessage, TextMessage } from "@/types/Message"
+import { ButtonMessage, MessageJson, TemplateMessage, TextMessage } from "@/types/Message"
 import ReceivedImageMessageUI from "./ReceivedImageMessageUI"
 import ReceivedTextMessageUI from "./ReceivedTextMessageUI"
 import TailWrapper from "./TailWrapper"
@@ -10,6 +10,7 @@ import ReceivedTemplateMessageUI from "./ReceivedTemplateMessageUI"
 import { markAsRead } from "./markAsRead"
 import ReceivedVideoMessageUI from "./ReceivedVideoMessageUI"
 import ReceivedDocumentMessageUI from "./ReceivedDocumentMessageUI"
+import ReceivedButtonMessageUI from "./ReceivedButtonMessageUI"
 import { useSupabase } from "@/components/supabase-provider"
 
 type UIMessageModel = DBMessage & {
@@ -206,6 +207,8 @@ export default function MessageListClient({ from }: { from: string }) {
                                                         return <ReceivedTemplateMessageUI message={messageBody as TemplateMessage} />
                                                     case "document":
                                                         return <ReceivedDocumentMessageUI message={message} />
+                                                    case "button":
+                                                        return <ReceivedButtonMessageUI buttonMessage={messageBody as ButtonMessage} />
                                                     default:
                                                         return <div>Unsupported message</div>
                                                 }

--- a/app/(authorized)/(panel)/chats/[wa_id]/ReceivedAudioMessageUI.tsx
+++ b/app/(authorized)/(panel)/chats/[wa_id]/ReceivedAudioMessageUI.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { AudioMessage } from "@/types/Message";
+import { useSupabase } from '@/components/supabase-provider'
+import { useEffect, useState } from 'react'
+
+type ReceivedAudioMessageUIProps = {
+    message: DBMessage
+}
+
+export default function ReceivedAudioMessageUI({ message }: ReceivedAudioMessageUIProps) {
+    const { supabase } = useSupabase()
+    const [audioUrl, setAudioUrl] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (message.media_url) {
+            supabase
+                .storage
+                .from('media')
+                .createSignedUrl(message.media_url, 60)
+                .then(({ data, error }) => {
+                    if (error) throw error
+                    setAudioUrl(data.signedUrl)
+                })
+                .catch(error => {
+                    console.error('Error loading audio:', error)
+                })
+        }
+    }, [message.media_url, supabase])
+
+    return (
+        <audio
+            controls
+            preload="metadata"
+            src={audioUrl || undefined}
+            className="w-full min-w-[280px]"
+            aria-label="Voice message"
+        />
+    )
+}

--- a/app/(authorized)/(panel)/chats/[wa_id]/ReceivedButtonMessageUI.tsx
+++ b/app/(authorized)/(panel)/chats/[wa_id]/ReceivedButtonMessageUI.tsx
@@ -1,0 +1,11 @@
+import { ButtonMessage } from "@/types/Message";
+
+export default function ReceivedButtonMessageUI(props: { buttonMessage: ButtonMessage }) {
+    const { buttonMessage } = props
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="text-sm text-gray-600">Button Reply:</div>
+            <div>{buttonMessage.button.text}</div>
+        </div>
+    )
+}

--- a/app/webhook/media.ts
+++ b/app/webhook/media.ts
@@ -16,9 +16,9 @@ function getFileExtensionFromContentDisposition(contentDisposition: string) {
 }
 
 export async function downloadMedia(imageMessage: WebhookMessage) {
-    const mediaDetails = imageMessage.image || imageMessage.video || imageMessage.document
+    const mediaDetails = imageMessage.image || imageMessage.video || imageMessage.document || imageMessage.audio
     if (!mediaDetails) {
-        throw new Error("image details not available in image key")
+        throw new Error("media details not available in message")
     }
     const headerOptions = {
         'Authorization': `Bearer ${process.env.WHATSAPP_ACCESS_TOKEN}`,

--- a/app/webhook/route.ts
+++ b/app/webhook/route.ts
@@ -79,7 +79,7 @@ export async function POST(request: NextRequest) {
             }), { onConflict: 'wam_id', ignoreDuplicates: true })
           if (error) throw new Error("Error while inserting messages to database", { cause: error})
           for (const message of messages) {
-            if (message.type === 'image' || message.type === 'video' || message.type === 'document') {
+            if (message.type === 'image' || message.type === 'video' || message.type === 'document' || message.type === 'audio') {
               await downloadMedia(message)
             }
           }

--- a/components/ui/template-selection.tsx
+++ b/components/ui/template-selection.tsx
@@ -157,27 +157,36 @@ export default function TemplateSelection({ children, onTemplateSubmit }: { chil
                         let headerVars: HeaderArg[] = []
                         switch (component.format) {
                             case "IMAGE": {
-                                headerVars.push({
-                                    argId: '{{1}}',
-                                    type: 'image',
-                                    link: '',
-                                })
+                                // Only ask for link if image is dynamic (not predefined)
+                                if (!component.image || component.example?.header_handle) {
+                                    headerVars.push({
+                                        argId: '{{1}}',
+                                        type: 'image',
+                                        link: '',
+                                    })
+                                }
                                 break;
                             }
                             case "VIDEO": {
-                                headerVars.push({
-                                    argId: '{{1}}',
-                                    type: 'video',
-                                    link: '',
-                                })
+                                // Only ask for link if video is dynamic (not predefined)
+                                if (!component.video || component.example?.header_handle) {
+                                    headerVars.push({
+                                        argId: '{{1}}',
+                                        type: 'video',
+                                        link: '',
+                                    })
+                                }
                                 break;
                             }
                             case "DOCUMENT": {
-                                headerVars.push({
-                                    argId: '{{1}}',
-                                    type: 'document',
-                                    link: '',
-                                })
+                                // Only ask for link if document is dynamic (not predefined)
+                                if (!component.document || component.example?.header_handle) {
+                                    headerVars.push({
+                                        argId: '{{1}}',
+                                        type: 'document',
+                                        link: '',
+                                    })
+                                }
                                 break;
                             }
                             case "TEXT": {
@@ -278,20 +287,24 @@ export default function TemplateSelection({ children, onTemplateSubmit }: { chil
                 }
             }
         }) as any
-        request.components.push({
-            type: "header",
-            parameters: headerArgs
-        })
+        if (headerArgs.length > 0) {
+            request.components.push({
+                type: "header",
+                parameters: headerArgs
+            })
+        }
         const bodyArgs: TextParameter[] = values.body.map((b) => {
             return {
                 type: 'text',
                 text: b.text
             }
         })
-        request.components.push({
-            type: "body",
-            parameters: bodyArgs
-        })
+        if (bodyArgs.length > 0) {
+            request.components.push({
+                type: "body",
+                parameters: bodyArgs
+            })
+        }
         const buttonPayloads: RequestComponent[] = values.button.map(b => {
             return {
                 type: 'button',

--- a/supabase/migrations/20251111230921_fix-rls-policies-with-fallback.sql
+++ b/supabase/migrations/20251111230921_fix-rls-policies-with-fallback.sql
@@ -1,0 +1,222 @@
+-- Fix RLS policies to work with Supabase SSR
+-- Issue: auth.jwt() ->> 'user_role' doesn't always work in RLS context
+-- Solution: Add fallback to check user_roles table directly
+
+-- ========================================
+-- CONTACTS TABLE POLICIES
+-- ========================================
+
+DROP POLICY IF EXISTS "Enable select for admin users and agent users to their contacts on contacts" ON "public"."contacts";
+
+CREATE POLICY "Enable select for admin and agent users"
+ON "public"."contacts"
+FOR SELECT
+TO authenticated
+USING (
+    -- Admin via JWT or user_roles table
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+    -- Agent via JWT or user_roles table (only for their assigned contacts)
+    OR (
+        (COALESCE((auth.jwt() ->> 'user_role') = 'agent', false)
+         OR auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'agent'))
+        AND auth.uid() = assigned_to
+    )
+);
+
+DROP POLICY IF EXISTS "Enable update for admin users and agent users to their contacts on contacts" ON "public"."contacts";
+
+CREATE POLICY "Enable update for admin and agent users"
+ON "public"."contacts"
+FOR UPDATE
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+    OR (
+        (COALESCE((auth.jwt() ->> 'user_role') = 'agent', false)
+         OR auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'agent'))
+        AND auth.uid() = assigned_to
+    )
+)
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+    OR (
+        (COALESCE((auth.jwt() ->> 'user_role') = 'agent', false)
+         OR auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'agent'))
+        AND auth.uid() = assigned_to
+    )
+);
+
+DROP POLICY IF EXISTS "Enable insert for admin users only on contacts" ON "public"."contacts";
+
+CREATE POLICY "Enable insert for admin users"
+ON "public"."contacts"
+FOR INSERT
+TO authenticated
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+);
+
+DROP POLICY IF EXISTS "Enable delete for admin users only on contacts" ON "public"."contacts";
+
+CREATE POLICY "Enable delete for admin users"
+ON "public"."contacts"
+FOR DELETE
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+);
+
+-- ========================================
+-- MESSAGES TABLE POLICIES
+-- ========================================
+
+DROP POLICY IF EXISTS "Enable select for admin users and agent users to their contacts on messages" ON "public"."messages";
+
+CREATE POLICY "Enable select for admin and agent users"
+ON "public"."messages"
+FOR SELECT
+TO authenticated
+USING (
+    -- Admin via JWT or user_roles table
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+    -- Agent via JWT or user_roles table (only for their assigned contacts)
+    OR (
+        (COALESCE((auth.jwt() ->> 'user_role') = 'agent', false)
+         OR auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'agent'))
+        AND chat_id::text IN (SELECT wa_id::text FROM contacts WHERE auth.uid() = assigned_to)
+    )
+);
+
+DROP POLICY IF EXISTS "Enable update for admin users and agent users to their contacts on messages" ON "public"."messages";
+
+CREATE POLICY "Enable update for admin and agent users"
+ON "public"."messages"
+FOR UPDATE
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+    OR (
+        (COALESCE((auth.jwt() ->> 'user_role') = 'agent', false)
+         OR auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'agent'))
+        AND chat_id::text IN (SELECT wa_id::text FROM contacts WHERE auth.uid() = assigned_to)
+    )
+)
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+    OR (
+        (COALESCE((auth.jwt() ->> 'user_role') = 'agent', false)
+         OR auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'agent'))
+        AND chat_id::text IN (SELECT wa_id::text FROM contacts WHERE auth.uid() = assigned_to)
+    )
+);
+
+DROP POLICY IF EXISTS "Enable insert for admin users and agent users to their contacts on messages" ON "public"."messages";
+
+CREATE POLICY "Enable insert for admin and agent users"
+ON "public"."messages"
+FOR INSERT
+TO authenticated
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+    OR (
+        (COALESCE((auth.jwt() ->> 'user_role') = 'agent', false)
+         OR auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'agent'))
+        AND chat_id::text IN (SELECT wa_id::text FROM contacts WHERE auth.uid() = assigned_to)
+    )
+);
+
+DROP POLICY IF EXISTS "Enable delete for admin users only on messages" ON "public"."messages";
+
+CREATE POLICY "Enable delete for admin users"
+ON "public"."messages"
+FOR DELETE
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+);
+
+-- ========================================
+-- BROADCAST TABLE POLICIES
+-- ========================================
+
+DROP POLICY IF EXISTS "Enable all for admin users only on broadcast" ON "public"."broadcast";
+
+CREATE POLICY "Enable all for admin users on broadcast"
+ON "public"."broadcast"
+FOR ALL
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+)
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+);
+
+-- ========================================
+-- BROADCAST_CONTACT TABLE POLICIES
+-- ========================================
+
+DROP POLICY IF EXISTS "Enable all for admin users only on broadcast_contact" ON "public"."broadcast_contact";
+
+CREATE POLICY "Enable all for admin users on broadcast_contact"
+ON "public"."broadcast_contact"
+FOR ALL
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+)
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+);
+
+-- ========================================
+-- BROADCAST_BATCH TABLE POLICIES
+-- ========================================
+
+DROP POLICY IF EXISTS "Enable all for admin users only on broadcast_batch" ON "public"."broadcast_batch";
+
+CREATE POLICY "Enable all for admin users on broadcast_batch"
+ON "public"."broadcast_batch"
+FOR ALL
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+)
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+);
+
+-- ========================================
+-- SETUP TABLE POLICIES
+-- ========================================
+
+DROP POLICY IF EXISTS "Enable all for admin users only on setup" ON "public"."setup";
+
+CREATE POLICY "Enable all for admin users on setup"
+ON "public"."setup"
+FOR ALL
+TO authenticated
+USING (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+)
+WITH CHECK (
+    COALESCE((auth.jwt() ->> 'user_role') = 'admin', false)
+    OR (auth.uid() IN (SELECT user_id FROM public.user_roles WHERE role = 'admin'))
+);

--- a/types/Message.ts
+++ b/types/Message.ts
@@ -29,3 +29,12 @@ export type TemplateMessage = MessageJson & {
 export type ImageMessage = MessageJson & {
     image: ImageMessageBody,
 }
+
+export type ButtonMessageBody = {
+    text: string,
+    payload: string,
+}
+
+export type ButtonMessage = MessageJson & {
+    button: ButtonMessageBody,
+}

--- a/types/Message.ts
+++ b/types/Message.ts
@@ -38,3 +38,13 @@ export type ButtonMessageBody = {
 export type ButtonMessage = MessageJson & {
     button: ButtonMessageBody,
 }
+
+export type AudioMessageBody = {
+    mime_type: string,
+    sha256: string,
+    id: string,
+}
+
+export type AudioMessage = MessageJson & {
+    audio: AudioMessageBody,
+}

--- a/types/webhook.d.ts
+++ b/types/webhook.d.ts
@@ -4,6 +4,11 @@ export type WebhookImage = {
     mime_type: string,
 }
 
+export type WebhookButton = {
+    text: string,
+    payload: string,
+}
+
 export type WebhookMessage = {
     from: string,
     id: string,
@@ -11,7 +16,8 @@ export type WebhookMessage = {
     image?: WebhookImage,
     video?: WebhookImage,
     document?: WebhookImage,
-    type: 'text' | 'reaction' | 'image' | 'video' | 'document',
+    button?: WebhookButton,
+    type: 'text' | 'reaction' | 'image' | 'video' | 'document' | 'button',
 }
 
 export type WebhookStatus = {

--- a/types/webhook.d.ts
+++ b/types/webhook.d.ts
@@ -16,8 +16,9 @@ export type WebhookMessage = {
     image?: WebhookImage,
     video?: WebhookImage,
     document?: WebhookImage,
+    audio?: WebhookImage,
     button?: WebhookButton,
-    type: 'text' | 'reaction' | 'image' | 'video' | 'document' | 'button',
+    type: 'text' | 'reaction' | 'image' | 'video' | 'document' | 'audio' | 'button',
 }
 
 export type WebhookStatus = {


### PR DESCRIPTION
  fix: Add RLS policy fallback and required setup steps

  Suggested PR Description:
  ## Problem
  Users deploying Receevi experience authentication issues where contacts
  and messages don't show up, even after following the setup guide. This
  is due to:
  1. RLS policies relying on `auth.jwt() ->> 'user_role'` which doesn't
  work reliably with Supabase SSR
  2. Missing steps in README for enabling auth hook and assigning user
  roles

  ## Solution
  ### RLS Policy Fix
  - Added fallback pattern to all RLS policies that checks `user_roles`
  table directly when JWT claim is unavailable
  - Created migration `20251111230921_fix-rls-policies-with-fallback.sql`
  that updates policies on:
    - `contacts` table (SELECT, INSERT, UPDATE, DELETE)
    - `messages` table (SELECT, INSERT, UPDATE, DELETE)
    - `broadcast`, `broadcast_contact`, `broadcast_batch` tables (ALL)
    - `setup` table (ALL)

  ### Documentation Updates
  - Added `CLAUDE.md` with comprehensive architecture docs and the RLS
  pattern explanation
  - Updated `README.md` with **required** steps:
    - Enable Custom Access Token auth hook in Supabase
    - Add admin role to first user via SQL

  ## Testing
  Tested on fresh Supabase deployment:
  - ✅ Auth hook working
  - ✅ User roles assigned
  - ✅ Contacts visible
  - ✅ Messages visible
  - ✅ All CRUD operations working

  ## Impact
  - **Existing deployments**: Need to run `supabase db push` to apply
  migration
  - **New deployments**: Will work correctly if README is followed
  - **Breaking changes**: None - this is additive